### PR TITLE
Fix some broken tests; use async filesystem wrapper

### DIFF
--- a/kerchunk/tests/test_combine.py
+++ b/kerchunk/tests/test_combine.py
@@ -134,16 +134,18 @@ xr.Dataset({"data": data}).to_zarr("memory://quad_2chunk2.zarr")
 # simple time arrays - xarray can't make these!
 m = fs.get_mapper("time1.zarr")
 z = zarr.open(m, mode="w", zarr_format=2)
-ar = z.create_dataset("time", data=np.array([1], dtype="M8[s]"))
+time1_array = np.array([1], dtype="M8[s]")
+ar = z.create_array("time", data=time1_array, shape=time1_array.shape)
 ar.attrs.update({"_ARRAY_DIMENSIONS": ["time"]})
-ar = z.create_dataset("data", data=arr)
+ar = z.create_array("data", data=arr, shape=arr.shape)
 ar.attrs.update({"_ARRAY_DIMENSIONS": ["time", "x", "y"]})
 
 m = fs.get_mapper("time2.zarr")
 z = zarr.open(m, mode="w", zarr_format=2)
-ar = z.create_dataset("time", data=np.array([2], dtype="M8[s]"))
+time2_array = np.array([2], dtype="M8[s]")
+ar = z.create_array("time", data=time2_array, shape=time2_array.shape)
 ar.attrs.update({"_ARRAY_DIMENSIONS": ["time"]})
-ar = z.create_dataset("data", data=arr)
+ar = z.create_array("data", data=arr, shape=arr.shape)
 ar.attrs.update({"_ARRAY_DIMENSIONS": ["time", "x", "y"]})
 
 

--- a/kerchunk/utils.py
+++ b/kerchunk/utils.py
@@ -9,6 +9,7 @@ import warnings
 import ujson
 
 import fsspec
+from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
 import numpy as np
 import zarr
 
@@ -70,6 +71,8 @@ def fs_as_store(fs: fsspec.asyn.AsyncFileSystem, mode="r"):
     zarr.storage.Store or zarr.storage.Mapper, fsspec.AbstractFileSystem
     """
     if is_zarr3():
+        if not fs.async_impl:
+            fs = AsyncFileSystemWrapper(fs)
         return zarr.storage.RemoteStore(fs, mode=mode)
     else:
         return fs.get_mapper()


### PR DESCRIPTION
This PR uses the upstream `AsyncFileSystemWrapper` from fsspec (pending merge) and fixes a test that used the deprecated `create_dataset` call